### PR TITLE
project: updated to use pairs instead of triples.

### DIFF
--- a/codeface/project.py
+++ b/codeface/project.py
@@ -42,14 +42,9 @@ def project_setup(conf, recreate):
     project_id = dbm.getProjectID(conf["project"], conf["tagging"])
     revs = conf["revisions"]
 
-    size = 3 # we want to use triplets
+    size = 2 # we want to use triplets
     # FIXME check that size of list is dividable by size
-    revs_new = [revs[i:i+size] for i  in range(0, len(revs), size)]
-
-    ranges = []
-    for (base, left, right) in revs_new:
-         ranges.append((base, left))
-         ranges.append((base, right))
+    ranges = [revs[i:i+size] for i  in range(0, len(revs), size)]
 
     all_range_ids = []
     for (start, end) in ranges:

--- a/codeface/project.py
+++ b/codeface/project.py
@@ -42,7 +42,7 @@ def project_setup(conf, recreate):
     project_id = dbm.getProjectID(conf["project"], conf["tagging"])
     revs = conf["revisions"]
 
-    size = 2 # we want to use triplets
+    size = 2 # we want to use pairs
     # FIXME check that size of list is dividable by size
     ranges = [revs[i:i+size] for i  in range(0, len(revs), size)]
 


### PR DESCRIPTION
with the new approach to the conflict analysis we don't need the tiples anymore, but pairs. More specifically, given the releases array _[a, b, c, d, e, f]_, the pairs _{(a,b),(c,d),(e,f)}_ must be analysed. Taking the pair (a,b) as a reference, '**a**'  is tag created by cotonet in a commit made a couple of months (e.g.,  3 months) before the base commit (the common ancestor) of a merge scenario, which cotonet tags as '**b**'.

Signed-off-by: Alcemir R. Santos <alcemir.santos@gmail.com>